### PR TITLE
Add Inter font and flexbox layout to forms

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap');
+
 /* Définition des variables de couleur */
 :root {
     --primary: #2563eb;
@@ -14,7 +16,7 @@
 
 /* Styles globaux */
 body {
-    font-family: Arial, sans-serif;
+    font-family: 'Inter', Arial, sans-serif;
     background-color: #e9f0f5;
     color: #333;
     margin: 0;
@@ -60,8 +62,13 @@ select {
     box-sizing: border-box;
 }
 
-/* Section de la méthode de localisation */
+/* Form sections */
+.route-selection,
+.departure-section,
 .location-section {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
     margin-bottom: 20px;
 }
 
@@ -70,7 +77,22 @@ label input[type="radio"] {
     margin-right: 5px;
 }
 
+.location-section {
+    background: var(--widget-glass);
+    padding: 12px;
+    border-radius: 8px;
+}
+
 /* Coordonnées manuelles */
+.manual-coords {
+    display: none;
+    flex-direction: column;
+    gap: 6px;
+    margin-top: 8px;
+}
+.manual-coords.visible {
+    display: flex;
+}
 .manual-coords label {
     margin-top: 5px;
 }

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
             <label><input type="radio" name="locationMethod" value="geo" checked> <i class="fas fa-location-arrow"></i> Use GPS</label>
             <label><input type="radio" name="locationMethod" value="manual"> <i class="fas fa-edit"></i> Manual input</label>
 
-            <div id="manualCoords" class="manual-coords" style="display:none;">
+            <div id="manualCoords" class="manual-coords">
                 <label for="manualLat">Latitude :</label>
                 <input type="number" id="manualLat" step="0.00001" placeholder="Enter latitude">
                 <label for="manualLon">Longitude :</label>

--- a/js/main.js
+++ b/js/main.js
@@ -55,8 +55,11 @@ function restoreSettings() {
     }
     if (savedLocationMethod) {
         document.querySelector(`input[name="locationMethod"][value="${savedLocationMethod}"]`).checked = true;
+        const manualDiv = document.getElementById('manualCoords');
         if (savedLocationMethod === 'manual') {
-            document.getElementById('manualCoords').style.display = 'block';
+            manualDiv.classList.add('visible');
+        } else {
+            manualDiv.classList.remove('visible');
         }
     }
     if (savedManualLat) {
@@ -150,12 +153,13 @@ function loadSelectedTrajet() {
 
 // Fonction pour configurer l'affichage des champs manuels en fonction de la méthode de localisation
 function setupLocationMethodListener() {
+    const manualDiv = document.getElementById('manualCoords');
     document.querySelectorAll('input[name="locationMethod"]').forEach((radio) => {
         radio.addEventListener('change', function () {
             if (this.value === 'manual') {
-                document.getElementById('manualCoords').style.display = 'block';
+                manualDiv.classList.add('visible');
             } else {
-                document.getElementById('manualCoords').style.display = 'none';
+                manualDiv.classList.remove('visible');
             }
         });
     });


### PR DESCRIPTION
## Summary
- import Inter font from Google Fonts and apply to page
- add modern flexbox layout classes for form sections
- toggle manual coordinate section visibility via CSS class
- clean inline styles in index.html

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68405077e6c483338e1117df84e22cf6