### PR TITLE
Wrap controls in form and align layout

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -33,6 +33,28 @@ body {
     box-shadow: 0 0 15px rgba(0, 0, 0, 0.1);
 }
 
+/* Form layout */
+#tracking-form {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+@media screen and (min-width: 768px) {
+    #tracking-form {
+        flex-direction: row;
+        flex-wrap: wrap;
+        align-items: flex-end;
+    }
+    #tracking-form > div {
+        flex: 1 1 200px;
+    }
+    #tracking-form .start-btn {
+        width: auto;
+        padding: 10px 20px;
+    }
+}
+
 /* Titres */
 h1 {
     font-size: 1.8em;

--- a/index.html
+++ b/index.html
@@ -12,32 +12,34 @@
 <body>
     <div class="container">
         <h1>Railway Timeline</h1>
-        <div class="route-selection">
-            <label for="routeSelect">Route selection:</label>
-            <select id="routeSelect" onchange="loadSelectedTrajet()">
-                <option value="">-- Select a route --</option>
-                <!-- Les options seront ajoutées dynamiquement via JavaScript -->
-            </select>
-        </div>
-
-        <div class="departure-section">
-            <label for="departure-time">Departure time (HH:MM):</label>
-            <input type="time" id="departure-time" required>
-        </div>
-
-        <div class="location-section">
-            <h4>Location:</h4>
-            <label><input type="radio" name="locationMethod" value="geo" checked> <i class="fas fa-location-arrow"></i> Use GPS</label>
-            <label><input type="radio" name="locationMethod" value="manual"> <i class="fas fa-edit"></i> Manual input</label>
-
-            <div id="manualCoords" class="manual-coords">
-                <label for="manualLat">Latitude :</label>
-                <input type="number" id="manualLat" step="0.00001" placeholder="Enter latitude">
-                <label for="manualLon">Longitude :</label>
-                <input type="number" id="manualLon" step="0.00001" placeholder="Enter longitude">
+        <form id="tracking-form">
+            <div class="route-selection">
+                <label for="routeSelect">Route selection:</label>
+                <select id="routeSelect" onchange="loadSelectedTrajet()">
+                    <option value="">-- Select a route --</option>
+                    <!-- Les options seront ajoutées dynamiquement via JavaScript -->
+                </select>
             </div>
-        </div>
-        <button class="start-btn" onclick="startTracking()">Start</button>
+
+            <div class="departure-section">
+                <label for="departure-time">Departure time (HH:MM):</label>
+                <input type="time" id="departure-time" required>
+            </div>
+
+            <div class="location-section">
+                <h4>Location:</h4>
+                <label><input type="radio" name="locationMethod" value="geo" checked> <i class="fas fa-location-arrow"></i> Use GPS</label>
+                <label><input type="radio" name="locationMethod" value="manual"> <i class="fas fa-edit"></i> Manual input</label>
+
+                <div id="manualCoords" class="manual-coords">
+                    <label for="manualLat">Latitude :</label>
+                    <input type="number" id="manualLat" step="0.00001" placeholder="Enter latitude">
+                    <label for="manualLon">Longitude :</label>
+                    <input type="number" id="manualLon" step="0.00001" placeholder="Enter longitude">
+                </div>
+            </div>
+            <button class="start-btn" type="submit">Start</button>
+        </form>
         <!-- widget -->
         <div id="tracking-widget" class="tracking-widget">
             <div class="widget-section">

--- a/js/main.js
+++ b/js/main.js
@@ -15,6 +15,12 @@ document.addEventListener('DOMContentLoaded', () => {
     setupLocationMethodListener();
     restoreSettings(); // Restaurer les paramètres sauvegardés
 
+    const form = document.getElementById('tracking-form');
+    form.addEventListener('submit', (e) => {
+        e.preventDefault();
+        startTracking();
+    });
+
     const timeline = document.getElementById('timeline');
     
     // Empêcher le scroll de la page quand on scroll dans la timeline


### PR DESCRIPTION
## Summary
- group route selector, time input, and location controls inside a `<form>`
- lay out the form horizontally on wide screens with flexbox
- hook the form's submit event in JavaScript

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684057c5c1f08333af5200c24f4feffd